### PR TITLE
Added BannerType2 and the ability to restrict banners to a certain season when requesting

### DIFF
--- a/MadTVDB.cs
+++ b/MadTVDB.cs
@@ -36,6 +36,12 @@ namespace MadTVDB
             return bannerResponse;
         }
 
+        public async Task<TVDBBannerResponse> SeriesBannerInformation(uint tvdbID, int season = -1, BannerType bannerType = BannerType.All)
+        {
+            TVDBBannerResponse bannerResponse = await _tvdbData.SeriesBannerInformation(tvdbID, season, bannerType);
+            return bannerResponse;
+        }
+
         public async Task<TVDBActorResponse> SeriesActorInformation(uint tvdbID)
         {
             TVDBActorResponse actorResponse = await _tvdbData.SeriesActorInformation(tvdbID);

--- a/Models/Banner.cs
+++ b/Models/Banner.cs
@@ -13,6 +13,16 @@ namespace MadTVDBPortable.Models
         All
     }
 
+    public enum BannerType2
+    {
+        Text,
+        Graphical,
+        Blank,
+        Res1080,
+        Res720,
+        Unknown
+    }
+
     [XmlRoot(ElementName = "Banner")]
     public class Banner
     {
@@ -45,8 +55,34 @@ namespace MadTVDBPortable.Models
             }
         }
 
+        public BannerType2 bannerType2
+        {
+            get
+            {
+                switch (_bannerType2)
+                {
+                    case "text":
+                        return BannerType2.Text;
+                    case "graphical":
+                        return BannerType2.Graphical;
+                    case "blank":
+                        return BannerType2.Blank;
+
+                    case "1920x1080":
+                        return BannerType2.Res1080;
+                    case "1280x720":
+                        return BannerType2.Res720;
+                }
+
+                return BannerType2.Unknown;
+            }
+        }
+
         [XmlElement(ElementName = "BannerType")]
         public string _bannerType { get; set; }
+
+        [XmlElement(ElementName = "BannerType2")]
+        public string _bannerType2 { get; set; }
 
         [XmlElement(ElementName = "Language")]
         public string language { get; set; }


### PR DESCRIPTION
BannerType2 in the banners.xml states if its a text, graphical, blank or the resolution of the fanart. Can be useful for some apps.
The season ID in the banners request just plonks a query in this code rather than the client app having to do it.